### PR TITLE
Shorten MAD8/MAD-X License

### DIFF
--- a/codes.json
+++ b/codes.json
@@ -65,7 +65,7 @@
     "institution_link" : "https://home.cern/",
     "repository" : "https://github.com/MethodicalAcceleratorDesign/MAD-X",
     "issue_tracker" : "https://github.com/MethodicalAcceleratorDesign/MAD-X/issues",
-    "license" : "SSDS",
+    "license" : "SDDS",
     "publication" : "H. Grote and F. Schmidt, 'MAD-X - An Upgrade from MAD8', Proceedings of the 2003 Particle Accelerator Conference, Vol. 5, 3497-3499 - 2003",
     "publication_link" : "https://doi.org/10.1109/pac.2003.1289960"
 

--- a/codes.json
+++ b/codes.json
@@ -65,7 +65,7 @@
     "institution_link" : "https://home.cern/",
     "repository" : "https://github.com/MethodicalAcceleratorDesign/MAD-X",
     "issue_tracker" : "https://github.com/MethodicalAcceleratorDesign/MAD-X/issues",
-    "license" : "https://github.com/MethodicalAcceleratorDesign/MAD-X/blob/master/License.txt",
+    "license" : "SSDS",
     "publication" : "H. Grote and F. Schmidt, 'MAD-X - An Upgrade from MAD8', Proceedings of the 2003 Particle Accelerator Conference, Vol. 5, 3497-3499 - 2003",
     "publication_link" : "https://doi.org/10.1109/pac.2003.1289960"
 


### PR DESCRIPTION
Although there is no standardized abbreviation ([SPDX identifier](https://en.wikipedia.org/wiki/Software_Package_Data_Exchange)) for this license, we can name it ["SDDS"](https://github.com/MethodicalAcceleratorDesign/MAD-X/blob/master/SDDS_LICENSE) as it is also called in the repo.

This is just to avoid breaking the layout on the homepage with a long link.